### PR TITLE
Alternative approach to syncronize artifacts from orderer on a failing step

### DIFF
--- a/add-new-org.yml
+++ b/add-new-org.yml
@@ -109,8 +109,10 @@
       delegate_to: localhost
 
     - name: Synchronize artifacts
-      synchronize: src="{{ fabric_artifacts }}/{{ item.from }}" dest="./artifacts/{{ item.to }}" mode=pull recursive=yes
-      loop: "{{ files_to_rsync_orderer }}"
+    - shell: (cd {{ fabric_artifacts }}; find . -maxdepth 1 -type f -iname "*.json") | rev | cut -d'/' -f1 | rev
+      register: files_to_copy
+    - fetch: src={{ fabric_artifacts }}/{{ item }} dest=./artifacts/
+      with_items: files_to_copy.stdout_lines
 
     when: "'peer' in node_roles and 'newcomer' in node_roles"
 

--- a/config-network.yml
+++ b/config-network.yml
@@ -99,8 +99,10 @@
       delegate_to: localhost
 
     - name: Synchronize artifacts
-      synchronize: src="{{ fabric_artifacts }}/{{ item.from }}" dest="./artifacts/{{ item.to }}" mode=pull recursive=yes
-      loop: "{{ files_to_rsync_orderer }}"
+    - shell: (cd {{ fabric_artifacts }}; find . -maxdepth 1 -type f -iname "*.json") | rev | cut -d'/' -f1 | rev
+      register: files_to_copy
+    - fetch: src={{ fabric_artifacts }}/{{ item }} dest=./artifacts/
+      with_items: files_to_copy.stdout_lines
 
     when: "'peer' in node_roles"
 


### PR DESCRIPTION
As mentioned o issue #2 I had many issues using rsync in this specific step.
After change to this approach using fetch I could run the script many times til end  without problems.

In the first step I gather all the file names since fetch dont allow to use wildcards like *

If you feel comfortable to accept this can use squash and merge to only generate one commit message.

Best regards

Closes #2 