### PR TITLE
Add docker image source: pull

### DIFF
--- a/roles/fabric/tasks/main.yml
+++ b/roles/fabric/tasks/main.yml
@@ -11,12 +11,14 @@
   docker_image:
     name: "{{ item.image }}:{{ item.version }}"
     state: present
+    source: pull
   loop: "{{ fabric_docker_images }}"
 
 - name: Pull kafka images
   docker_image:
     name: "{{ item.image }}:{{ item.version }}"
     state: present
+    source: pull
   loop: "{{ kafka_docker_images }}"
   when: "'kafka' in orderer_type"
 
@@ -24,5 +26,7 @@
   docker_image:
     name: "{{ item.image }}:{{ item.version }}"
     state: present
+    source: pull
   loop: "{{ explorer_docker_images }}"
   when: "'explorer' in node_roles"
+


### PR DESCRIPTION
Since Ansible 2.8 this message appears, if the `docker_image` task is missing a `source`:

>[WARNING]: The value of the "source" option was determined to be "pull". Please set the "source" option explicitly. Autodetection will be removed in Ansible 2.12.

This pullrequest fixes this and will avoid the install from breaking with ansible 2.12+.
